### PR TITLE
Add optional test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Or set environment variables:
 - `TASTYTRADE_USERNAME`
 - `TASTYTRADE_PASSWORD`
 - `TASTYTRADE_ACCOUNT_ID` (optional - uses first account if multiple)
+- `TASTYTRADE_IS_TEST` (optional - `true` for the test environment, `false` or
+  unset for live trading)
+
+By default the server connects to the live Tastytrade environment. Set the
+variable to `true` when you want to experiment safely using the test
+environment without affecting live positions.
 
 ## MCP Tools
 
@@ -27,6 +33,7 @@ Or set environment variables:
 - **`get_account_balances`** - Get current cash balance, buying power, net liquidating value, and maintenance excess
   - Always returns fresh data from TastyTrade API
   - No parameters required
+  - In the test environment, buying power values are not provided by the API and default to the cash balance
 
 - **`get_current_positions`** - Get all open stock and option positions
   - Includes symbol, type, quantity, mark price, and current value

--- a/tasty_agent/cli.py
+++ b/tasty_agent/cli.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import keyring
 from getpass import getpass
 import click
@@ -32,7 +33,9 @@ def setup():
         keyring.set_password("tastytrade", "username", username)
         keyring.set_password("tastytrade", "password", password)
 
-        session = Session(username, password)
+        # Use the test environment when TASTYTRADE_IS_TEST is set to "true"
+        is_test = os.getenv("TASTYTRADE_IS_TEST", "false").lower() in ("true", "1", "yes")
+        session = Session(username, password, is_test=is_test)
         accounts = Account.get(session)
 
         if len(accounts) > 1:


### PR DESCRIPTION
## Summary
- add `TASTYTRADE_IS_TEST` environment variable
- respect the variable in CLI and server when creating `Session`
- make buying power equal cash balance in test mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685182fe2844832e8a4bdffaa3744156