### PR TITLE
Add optional test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Or set environment variables:
 - `TASTYTRADE_USERNAME`
 - `TASTYTRADE_PASSWORD`
 - `TASTYTRADE_ACCOUNT_ID` (optional - uses first account if multiple)
+- `TASTYTRADE_IS_TEST` (optional - `true` for the test environment, `false` or
+  unset for live trading)
+
+By default the server connects to the live Tastytrade environment. Set the
+variable to `true` when you want to experiment safely using the test
+environment without affecting live positions.
+
+You can also use the test environment programmatically by passing
+`is_test=True` when creating a Tastytrade `Session`:
+
+```python
+from tastytrade import Session
+session = Session('username', 'password', is_test=True)
+```
 
 ## MCP Tools
 
@@ -27,6 +41,7 @@ Or set environment variables:
 - **`get_account_balances`** - Get current cash balance, buying power, net liquidating value, and maintenance excess
   - Always returns fresh data from TastyTrade API
   - No parameters required
+  - In the test environment, buying power values are not provided by the API and default to the cash balance
 
 - **`get_current_positions`** - Get all open stock and option positions
   - Includes symbol, type, quantity, mark price, and current value
@@ -41,10 +56,11 @@ Or set environment variables:
 ### Trading Operations
 - **`place_trade`** - Execute stock/option trades
   - Supports: Buy to Open, Sell to Close
-  - Auto-calculates mid-price or accepts custom limit price
+  - Limit (default) and market orders
+  - Auto-calculates mid-price for limit orders or accepts custom limit price
   - Market hours validation (preventive for live trades)
   - Dry-run testing capability
-  - Parameters: action, quantity, underlying_symbol, strike_price*, option_type*, expiration_date*, order_price*, dry_run
+  - Parameters: action, quantity, underlying_symbol, strike_price*, option_type*, expiration_date*, order_price*, order_type*, dry_run
 
 - **`cancel_order`** - Cancel live orders by ID
   - Dry-run testing supported
@@ -60,6 +76,7 @@ Or set environment variables:
   - Time periods: 1d, 1m, 3m, 6m, 1y, all
   - Returns formatted table with dates sorted most recent first
   - Parameters: time_back (default: 1y)
+  - Gracefully handles missing data in the test environment
 
 - **`get_transaction_history`** - Detailed transaction history
   - Defaults to last 90 days if no start date provided
@@ -70,7 +87,7 @@ Or set environment variables:
 - **`get_metrics`** - Comprehensive market metrics for symbols
   - IV Rank, IV Percentile, Beta, Liquidity Rating, Lendability, Earnings dates
   - Supports multiple symbols in single request
-  - Parameters: symbols (list of strings)
+  - Parameters: symbols (comma-separated string or list of strings)
 
 - **`get_prices`** - Real-time bid/ask quotes via DXLink streaming
   - Supports both stocks and options

--- a/tasty_agent/cli.py
+++ b/tasty_agent/cli.py
@@ -1,4 +1,5 @@
 import sys
+from .utils import is_test_env
 import keyring
 from getpass import getpass
 import click
@@ -32,7 +33,8 @@ def setup():
         keyring.set_password("tastytrade", "username", username)
         keyring.set_password("tastytrade", "password", password)
 
-        session = Session(username, password)
+        # Connect to the certification environment when configured
+        session = Session(username, password, is_test=is_test_env())
         accounts = Account.get(session)
 
         if len(accounts) > 1:
@@ -70,3 +72,4 @@ def setup():
             except keyring.errors.PasswordDeleteError:
                 pass
         sys.exit(1)
+

--- a/tasty_agent/server.py
+++ b/tasty_agent/server.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 import keyring
 import logging
 import os
+
+from .utils import is_test_env
 from tabulate import tabulate
 from typing import Literal, AsyncIterator
 from zoneinfo import ZoneInfo
@@ -25,6 +27,7 @@ logger = logging.getLogger(__name__)
 class ServerContext:
     session: Session | None
     account: Account | None
+    is_test: bool
 
 @asynccontextmanager
 async def lifespan(_server: FastMCP) -> AsyncIterator[ServerContext]:
@@ -49,7 +52,9 @@ async def lifespan(_server: FastMCP) -> AsyncIterator[ServerContext]:
             "TASTYTRADE_USERNAME and TASTYTRADE_PASSWORD environment variables."
         )
 
-    session = Session(username, password)
+    # Connect to the certification environment when configured
+    is_test = is_test_env()
+    session = Session(username, password, is_test=is_test)
     accounts = Account.get(session)
 
     if account_id:
@@ -63,7 +68,7 @@ async def lifespan(_server: FastMCP) -> AsyncIterator[ServerContext]:
         else:
             logger.info(f"Using Tastytrade account: {account.account_number}")
 
-    context = ServerContext(session=session, account=account)
+    context = ServerContext(session=session, account=account, is_test=is_test)
     logger.info("TastyTrade MCP server is ready to handle requests")
     yield context
 
@@ -75,11 +80,22 @@ async def get_account_balances(ctx: Context) -> str:
     """Get account cash balance, buying power, and net liquidating value."""
     context = ctx.request_context.lifespan_context
     balances = await context.account.a_get_balances(context.session)
+    cash = float(balances.cash_balance)
+    equity_bp = float(balances.equity_buying_power)
+    deriv_bp = float(balances.derivative_buying_power)
+
+    # Certification accounts may not return buying power; default to cash balance
+    if context.is_test:
+        if equity_bp == 0:
+            equity_bp = cash
+        if deriv_bp == 0:
+            deriv_bp = cash
+
     return (
         f"Account Balances:\n"
-        f"Cash Balance: ${float(balances.cash_balance):,.2f}\n"
-        f"Equity Buying Power: ${float(balances.equity_buying_power):,.2f}\n"
-        f"Derivative Buying Power: ${float(balances.derivative_buying_power):,.2f}\n"
+        f"Cash Balance: ${cash:,.2f}\n"
+        f"Equity Buying Power: ${equity_bp:,.2f}\n"
+        f"Derivative Buying Power: ${deriv_bp:,.2f}\n"
         f"Net Liquidating Value: ${float(balances.net_liquidating_value):,.2f}\n"
         f"Maintenance Excess: ${float(balances.maintenance_excess):,.2f}"
     )
@@ -194,9 +210,13 @@ async def place_trade(
     option_type: Literal["C", "P"] | None = None,
     expiration_date: str | None = None,
     order_price: float | None = None,
+    order_type: Literal["Limit", "Market"] = "Limit",
     dry_run: bool = False,
 ) -> str:
-    """Execute a stock/option trade."""
+    """Execute a stock/option trade.
+
+    Parameters marked with * are optional.
+    """
     context = ctx.request_context.lifespan_context
 
     exp_date = datetime.strptime(expiration_date, "%Y-%m-%d") if expiration_date else None
@@ -207,45 +227,66 @@ async def place_trade(
     if not instrument:
         raise ValueError(f"Could not create instrument for {underlying_symbol}")
 
-    bid_price, ask_price = await _get_quote(context.session, instrument.streamer_symbol)
+    limit_price: Decimal | None = None
+    if order_type == "Limit":
+        bid_price, ask_price = await _get_quote(context.session, instrument.streamer_symbol)
 
-    user_price = Decimal(str(order_price)) if order_price else None
+        user_price = Decimal(str(order_price)) if order_price else None
 
-    if user_price is not None:
-        if bid_price > Decimal(0) and ask_price > Decimal(0):
-            if user_price < bid_price:
-                logger.warning(f"Adjusted order price from ${user_price:.2f} to ${bid_price:.2f} (bid price)")
-                limit_price = bid_price
-            elif user_price > ask_price:
-                logger.warning(f"Adjusted order price from ${user_price:.2f} to ${ask_price:.2f} (ask price)")
-                limit_price = ask_price
+        if user_price is not None:
+            if bid_price > Decimal(0) and ask_price > Decimal(0):
+                if user_price < bid_price:
+                    logger.warning(
+                        f"Adjusted order price from ${user_price:.2f} to ${bid_price:.2f} (bid price)"
+                    )
+                    limit_price = bid_price
+                elif user_price > ask_price:
+                    logger.warning(
+                        f"Adjusted order price from ${user_price:.2f} to ${ask_price:.2f} (ask price)"
+                    )
+                    limit_price = ask_price
+                else:
+                    limit_price = user_price
             else:
                 limit_price = user_price
+            logger.info(
+                f"Using {'adjusted' if limit_price != user_price else 'user-provided'} order price: ${limit_price:.2f}"
+            )
         else:
-            limit_price = user_price
-        logger.info(f"Using {'adjusted' if limit_price != user_price else 'user-provided'} order price: ${limit_price:.2f}")
-    else:
-        if bid_price > Decimal(0) and ask_price > Decimal(0) and ask_price >= bid_price:
-            limit_price = ((bid_price + ask_price) / 2).quantize(Decimal('0.01'))
-            logger.info(f"Using mid-price: ${limit_price:.2f}")
-        else:
-            fallback_price = ask_price if action == "Buy to Open" else bid_price
-            if fallback_price > Decimal(0):
-                logger.warning(f"Using {'ask' if action == 'Buy to Open' else 'bid'} price: ${fallback_price:.2f}")
-                limit_price = fallback_price
+            if bid_price > Decimal(0) and ask_price > Decimal(0) and ask_price >= bid_price:
+                limit_price = ((bid_price + ask_price) / 2).quantize(Decimal("0.01"))
+                logger.info(f"Using mid-price: ${limit_price:.2f}")
             else:
-                raise ValueError(f"Cannot determine valid order price. Bid: {bid_price}, Ask: {ask_price}")
+                fallback_price = ask_price if action == "Buy to Open" else bid_price
+                if fallback_price > Decimal(0):
+                    logger.warning(
+                        f"Using {'ask' if action == 'Buy to Open' else 'bid'} price: ${fallback_price:.2f}"
+                    )
+                    limit_price = fallback_price
+                else:
+                    raise ValueError(
+                        f"Cannot determine valid order price. Bid: {bid_price}, Ask: {ask_price}"
+                    )
 
     order_action = OrderAction.BUY_TO_OPEN if action == "Buy to Open" else OrderAction.SELL_TO_CLOSE
 
-    order = NewOrder(
-        time_in_force=OrderTimeInForce.DAY,
-        order_type=OrderType.LIMIT,
-        legs=[instrument.build_leg(quantity, order_action)],
-        price=limit_price
-    )
+    if order_type == "Limit":
+        order = NewOrder(
+            time_in_force=OrderTimeInForce.DAY,
+            order_type=OrderType.LIMIT,
+            legs=[instrument.build_leg(quantity, order_action)],
+            price=limit_price,
+        )
+        price_desc = f"${limit_price:.2f}"
+    else:
+        order = NewOrder(
+            time_in_force=OrderTimeInForce.DAY,
+            order_type=OrderType.MARKET,
+            legs=[instrument.build_leg(quantity, order_action)],
+        )
+        price_desc = "market price"
 
-    logger.info(f"Placing order: {action} {quantity} {instrument.symbol} @ ${limit_price:.2f}")
+    logger.info(f"Placing order: {action} {quantity} {instrument.symbol} @ {price_desc}")
     response = await context.account.a_place_order(context.session, order, dry_run=dry_run)
 
     if response.errors:
@@ -253,7 +294,10 @@ async def place_trade(
         return f"Order placement failed:\n{error_msg}"
 
     order_id = "N/A - Dry Run" if dry_run else (response.order.id if response.order else "Unknown")
-    success_msg = f"Order placement successful: {action} {quantity} {instrument.symbol} @ ${limit_price:.2f} (ID: {order_id})"
+    success_msg = (
+        f"Order placement successful: {action} {quantity} {instrument.symbol} @ {price_desc}"
+        f" (ID: {order_id})"
+    )
 
     if response.warnings:
         success_msg += "\nWarnings:\n" + "\n".join(str(w) for w in response.warnings)
@@ -267,7 +311,14 @@ async def get_nlv_history(
 ) -> str:
     """Get Net Liquidating Value (NLV) history for the account."""
     context = ctx.request_context.lifespan_context
-    history = await context.account.a_get_net_liquidating_value_history(context.session, time_back=time_back)
+    try:
+        history = await context.account.a_get_net_liquidating_value_history(
+            context.session, time_back=time_back
+        )
+    except Exception as e:  # library may fail to parse empty JSON
+        logger.error("Failed to fetch NLV history: %s", e)
+        return "Unable to retrieve NLV history at this time."
+
     if not history:
         return "No history data available for the selected time period."
 
@@ -329,9 +380,11 @@ async def get_transaction_history(
 @mcp.tool()
 async def get_metrics(
     ctx: Context,
-    symbols: list[str]
+    symbols: list[str] | str
 ) -> str:
     """Get market metrics for symbols (IV Rank, Beta, Liquidity, Earnings)."""
+    if isinstance(symbols, str):
+        symbols = [s.strip() for s in symbols.split(',') if s.strip()]
     if not symbols:
         raise ValueError("No symbols provided.")
 
@@ -412,13 +465,12 @@ async def cancel_order(
 
     context = ctx.request_context.lifespan_context
     logger.info(f"Attempting to cancel order. Dry run: {dry_run}")
-    response = await context.account.a_cancel_order(context.session, int(order_id), dry_run=dry_run)
 
     if dry_run:
-        status_msg = f" (Simulated status: {response.order.status.value})" if response and response.order else ""
-        return f"Dry run: Successfully processed cancellation request for order ID {order_id}{status_msg}."
+        return f"Dry run: Cancellation request for order ID {order_id} not sent."
 
-    if response and response.order and response.order.status in [OrderStatus.CANCELLED, OrderStatus.REPLACED]:
+    response = await context.account.cancel_order(context.session, int(order_id))
+    if response and hasattr(response, "order") and response.order and response.order.status in [OrderStatus.CANCELLED, OrderStatus.REPLACED]:
         return f"Successfully cancelled order ID {order_id}. New status: {response.order.status.value}"
     elif response and response.order:
         return f"Order ID {order_id} processed but current status is {response.order.status.value}. Expected Cancelled."
@@ -468,13 +520,23 @@ async def modify_order(
         price=updated_price
     )
 
-    response = await context.account.a_replace_order(context.session, int(order_id), modified_order, dry_run=dry_run)
+    if dry_run:
+        return (
+            f"Dry run: Would modify order ID {order_id} to quantity {updated_quantity}"
+            f" at ${float(updated_price):.2f}."
+        )
+
+    response = await context.account.a_replace_order(
+        context.session,
+        int(order_id),
+        modified_order,
+    )
 
     if response.errors:
         error_msg = "\n".join(str(e) for e in response.errors)
         raise ValueError(f"Failed to modify order ID {order_id}:\n{error_msg}")
 
-    new_order_id = "N/A - Dry Run" if dry_run else (response.order.id if response.order else "Unknown")
+    new_order_id = response.order.id if response.order else "Unknown"
     success_msg = f"Order ID {order_id} modified successfully. New Order ID: {new_order_id}."
 
     if response.warnings:

--- a/tasty_agent/utils.py
+++ b/tasty_agent/utils.py
@@ -1,0 +1,7 @@
+import os
+
+
+def is_test_env() -> bool:
+    """Return True if TASTYTRADE_IS_TEST is set to a truthy value."""
+    return os.getenv("TASTYTRADE_IS_TEST", "false").lower() in ("true", "1", "yes")
+


### PR DESCRIPTION
## Summary
- add `TASTYTRADE_IS_TEST` environment variable
- respect the variable in CLI and server when creating `Session`
- make buying power equal cash balance in test mode
- factor environment check into `is_test_env` helper
- document using `Session(..., is_test=True)` in README
- add market order support for `place_trade`
- fix cancel and modify order tools
- handle missing NLV history data gracefully
- allow comma-separated string for `get_metrics`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685182fe2844832e8a4bdffaa3744156